### PR TITLE
[Reviewer: Rob] Fix Liberty by performing null string replacement on network ID

### DIFF
--- a/bono.yaml
+++ b/bono.yaml
@@ -125,6 +125,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
@@ -138,6 +139,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: bono_sig_security_group }

--- a/bono.yaml
+++ b/bono.yaml
@@ -125,7 +125,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
 
@@ -138,7 +138,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_sig_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: bono_sig_security_group }
 

--- a/dns.yaml
+++ b/dns.yaml
@@ -97,7 +97,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: dns_security_group }
 
@@ -110,7 +110,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_sig_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: dns_security_group }
 

--- a/dns.yaml
+++ b/dns.yaml
@@ -97,6 +97,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: dns_security_group }
@@ -110,6 +111,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: dns_security_group }

--- a/ellis.yaml
+++ b/ellis.yaml
@@ -116,7 +116,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
         - { get_param: ellis_mgmt_security_group }

--- a/ellis.yaml
+++ b/ellis.yaml
@@ -116,6 +116,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }

--- a/homer.yaml
+++ b/homer.yaml
@@ -128,6 +128,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
@@ -142,6 +143,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: homer_sig_security_group }

--- a/homer.yaml
+++ b/homer.yaml
@@ -128,7 +128,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
         - { get_param: homer_mgmt_security_group }
@@ -142,7 +142,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_sig_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: homer_sig_security_group }
 

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -128,7 +128,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
         - { get_param: homestead_mgmt_security_group }
@@ -142,7 +142,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_sig_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: homestead_sig_security_group }
 

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -128,6 +128,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
@@ -142,6 +143,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: homestead_sig_security_group }

--- a/network.yaml
+++ b/network.yaml
@@ -86,7 +86,7 @@ resources:
     type: OS::Neutron::Subnet
     properties:
       name: { get_param: private_net_name }
-      network_id: { get_resource: private_net }
+      network_id: { str_replace: { params: { x: { get_resource: private_net } }, template: x } }
       ip_version: { get_param: private_net_ip_version }
       cidr: { get_param: private_net_cidr }
       dns_nameservers: [ { get_param: dns_ip } ]
@@ -104,7 +104,7 @@ resources:
     type: OS::Neutron::RouterGateway
     properties:
       router_id: { get_resource: router }
-      network_id: { get_param: public_net_id }
+      network_id: { str_replace: { params: { x: { get_param: public_net_id } }, template: x } }
 
   router_interface:
     type: OS::Neutron::RouterInterface

--- a/network.yaml
+++ b/network.yaml
@@ -86,7 +86,7 @@ resources:
     type: OS::Neutron::Subnet
     properties:
       name: { get_param: private_net_name }
-      network_id: { str_replace: { params: { x: { get_resource: private_net } }, template: x } }
+      network_id: { get_resource: private_net }
       ip_version: { get_param: private_net_ip_version }
       cidr: { get_param: private_net_cidr }
       dns_nameservers: [ { get_param: dns_ip } ]
@@ -104,7 +104,7 @@ resources:
     type: OS::Neutron::RouterGateway
     properties:
       router_id: { get_resource: router }
-      network_id: { str_replace: { params: { x: { get_param: public_net_id } }, template: x } }
+      network_id: { get_param: public_net_id }
 
   router_interface:
     type: OS::Neutron::RouterInterface

--- a/ralf.yaml
+++ b/ralf.yaml
@@ -125,6 +125,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
@@ -138,6 +139,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: ralf_sig_security_group }

--- a/ralf.yaml
+++ b/ralf.yaml
@@ -125,7 +125,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
 
@@ -138,7 +138,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_sig_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: ralf_sig_security_group }
 

--- a/sprout.yaml
+++ b/sprout.yaml
@@ -128,6 +128,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
@@ -141,6 +142,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
+      # Specify the network ID by string to work around OpenStack issues - see https://github.com/Metaswitch/clearwater-heat/issues/18.
       network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: sprout_sig_security_group }

--- a/sprout.yaml
+++ b/sprout.yaml
@@ -128,7 +128,7 @@ resources:
   mgmt_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_mgmt_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_mgmt_net_id } }, template: x } }
       security_groups:
         - { get_param: base_mgmt_security_group }
 
@@ -141,7 +141,7 @@ resources:
   sig_port:
     type: OS::Neutron::Port
     properties:
-      network_id: { get_param: private_sig_net_id }
+      network_id: { str_replace: { params: { x: { get_param: private_sig_net_id } }, template: x } }
       security_groups:
         - { get_param: sprout_sig_security_group }
         - { get_param: sprout_sig2_security_group }


### PR DESCRIPTION
Rob,

Please can you review this fix to #18?  It's a bit unpleasant, but it seems the only way to work-around this behavior in OpenStack.

Tested live on Liberty.

Matt
