### PR TITLE
[Reviewer: Rob] I-CSCF default and apply-shared-config removal

### DIFF
--- a/bono.yaml
+++ b/bono.yaml
@@ -231,10 +231,6 @@ resources:
             DEBIAN_FRONTEND=noninteractive apt-get install bono --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-config-manager --yes --force-yes
 
-            # Wait until etcd is up and running before applying the shared_config
-            /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
-            sudo /usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config --sync
-
             # Function to give DNS record type and IP address for specified IP address
             ip2rr() {
               if echo $1 | grep -q -e '[^0-9.]' ; then

--- a/ellis.yaml
+++ b/ellis.yaml
@@ -176,7 +176,7 @@ resources:
             DEBIAN_FRONTEND=noninteractive apt-get install ellis --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-config-manager --yes --force-yes
 
-            # Wait until etcd is up and running before uploading/adding the shared_config
+            # Wait until etcd is up and running before uploading the shared_config
             /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
 
             # Configure and upload /etc/clearwater/shared_config.
@@ -189,7 +189,7 @@ resources:
             ralf_hostname=ralf.__zone__:10888
             xdms_hostname=homer.__zone__:7888
             
-            upstream_hostname=scscf.sprout.__zone__
+            upstream_hostname=icscf.sprout.__zone__
             upstream_port=0
 
             # Email server configuration
@@ -205,7 +205,6 @@ resources:
             ellis_cookie_key=secret
             EOF
             sudo /usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
-            sudo /usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config --sync
 
             # Tweak /etc/clearwater/shared_config to use homer's management hostname instead of signaling.
             # This works around https://github.com/Metaswitch/ellis/issues/153.

--- a/ellis.yaml
+++ b/ellis.yaml
@@ -190,7 +190,6 @@ resources:
             ralf_hostname=ralf.__zone__:10888
             xdms_hostname=homer.__zone__:7888
             
-            upstream_hostname=icscf.sprout.__zone__
             upstream_port=0
 
             # Email server configuration

--- a/homer.yaml
+++ b/homer.yaml
@@ -236,10 +236,6 @@ resources:
             DEBIAN_FRONTEND=noninteractive apt-get install homer --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
-            # Wait until etcd is up and running before applying the shared_config
-            /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
-            sudo /usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config --sync
-
             # Function to give DNS record type and IP address for specified IP address
             ip2rr() {
               if echo $1 | grep -q -e '[^0-9.]' ; then

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -228,10 +228,6 @@ resources:
             DEBIAN_FRONTEND=noninteractive apt-get install homestead homestead-prov clearwater-prov-tools --yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
-            # Wait until etcd is up and running before applying the shared_config
-            /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
-            sudo /usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config --sync
-
             # Function to give DNS record type and IP address for specified IP address
             ip2rr() {
               if echo $1 | grep -q -e '[^0-9.]' ; then

--- a/ralf.yaml
+++ b/ralf.yaml
@@ -243,10 +243,6 @@ resources:
             DEBIAN_FRONTEND=noninteractive apt-get install ralf --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
-            # Wait until etcd is up and running before applying the shared_config
-            /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
-            sudo /usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config --sync
-
             # Function to give DNS record type and IP address for specified IP address
             ip2rr() {
               if echo $1 | grep -q -e '[^0-9.]' ; then

--- a/sprout.yaml
+++ b/sprout.yaml
@@ -247,10 +247,6 @@ resources:
             DEBIAN_FRONTEND=noninteractive apt-get install sprout --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
-            # Wait until etcd is up and running before applying the shared_config
-            /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
-            sudo /usr/share/clearwater/clearwater-config-manager/scripts/apply_shared_config --sync
-
             # Function to give DNS record type and IP address for specified IP address
             ip2rr() {
               if echo $1 | grep -q -e '[^0-9.]' ; then


### PR DESCRIPTION
Remove upstream hostname setting in the heat templates. This also tidies up some left over apply-shared-config scripts. 

Part of enabling I-CSCF function by default.
