### PR TITLE
[Reviewer: AJL] Use split-storage package names

### DIFF
--- a/bono.yaml
+++ b/bono.yaml
@@ -231,7 +231,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install bono --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install bono-node --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Function to give DNS record type and IP address for specified IP address

--- a/ellis.yaml
+++ b/ellis.yaml
@@ -175,7 +175,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install ellis --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install ellis-node --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Wait until etcd is up and running before uploading the shared_config
@@ -190,7 +190,7 @@ resources:
             hs_provisioning_hostname=hs-prov.__zone__:8889
             ralf_hostname=ralf.__zone__:10888
             xdms_hostname=homer.__zone__:7888
-            
+
             upstream_port=0
 
             # Email server configuration
@@ -198,7 +198,7 @@ resources:
             smtp_username=username
             smtp_password=password
             email_recovery_sender=clearwater@example.org
-            
+
             # Keys
             signup_key=secret
             turn_workaround=secret

--- a/homer.yaml
+++ b/homer.yaml
@@ -235,7 +235,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install homer --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install homer-node --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Function to give DNS record type and IP address for specified IP address

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -228,7 +228,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install homestead-node homestead-node-prov clearwater-prov-tools --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install homestead-node clearwater-prov-tools --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Function to give DNS record type and IP address for specified IP address

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -228,7 +228,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install homestead homestead-prov clearwater-prov-tools --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install homestead-node homestead-node-prov clearwater-prov-tools --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Function to give DNS record type and IP address for specified IP address

--- a/ralf.yaml
+++ b/ralf.yaml
@@ -243,7 +243,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install ralf --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install ralf-node --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Function to give DNS record type and IP address for specified IP address

--- a/sprout.yaml
+++ b/sprout.yaml
@@ -247,7 +247,7 @@ resources:
             EOF
 
             # Now install the software.
-            DEBIAN_FRONTEND=noninteractive apt-get install sprout --yes --force-yes
+            DEBIAN_FRONTEND=noninteractive apt-get install sprout-node --yes --force-yes
             DEBIAN_FRONTEND=noninteractive apt-get install clearwater-management --yes --force-yes
 
             # Function to give DNS record type and IP address for specified IP address


### PR DESCRIPTION
Seemed pretty straightforward like you said.  Just renamed the packages to the "-node" versions.
