### PR TITLE
[Reviewer: RKD] A better workaround to Ellis issue 153

### DIFF
--- a/ellis.yaml
+++ b/ellis.yaml
@@ -163,7 +163,9 @@ resources:
             curl -L http://repo.cw-ngv.com/repo_key | apt-key add -
             apt-get update
 
-            # Configure /etc/clearwater/local_config.
+            # Configure /etc/clearwater/local_config.  Add xdms_hostname here to use Homer's management
+            # hostname instead of signaling.  This will override shared_config.  This works around
+            # https://github.com/Metaswitch/ellis/issues/153.
             mkdir -p /etc/clearwater
             etcd_ip=__etcd_ip__
             [ -n "$etcd_ip" ] || etcd_ip=__private_mgmt_ip__
@@ -172,6 +174,7 @@ resources:
             public_ip=__public_mgmt_ip__
             public_hostname=ellis-__index__.__zone__
             etcd_cluster=$etcd_ip
+            xdms_hostname=homer-0.__zone__:7888
             EOF
 
             # Now install the software.
@@ -190,7 +193,7 @@ resources:
             hs_provisioning_hostname=hs-prov.__zone__:8889
             ralf_hostname=ralf.__zone__:10888
             xdms_hostname=homer.__zone__:7888
-            
+
             upstream_port=0
 
             # Email server configuration
@@ -198,7 +201,7 @@ resources:
             smtp_username=username
             smtp_password=password
             email_recovery_sender=clearwater@example.org
-            
+
             # Keys
             signup_key=secret
             turn_workaround=secret
@@ -206,12 +209,6 @@ resources:
             ellis_cookie_key=secret
             EOF
             sudo /usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
-
-            # Tweak /etc/clearwater/shared_config to use homer's management hostname instead of signaling.
-            # This works around https://github.com/Metaswitch/ellis/issues/153.
-            sed -e 's/^xdms_hostname=.*$/xdms_hostname=homer-0.__zone__:7888/g' -i /etc/clearwater/shared_config
-            service clearwater-infrastructure restart
-            service ellis stop
 
             # Allocate a allocate a pool of numbers to assign to users.
             /usr/share/clearwater/ellis/env/bin/python /usr/share/clearwater/ellis/src/metaswitch/ellis/tools/create_numbers.py --start __dn_range_start__ --count __dn_range_length__


### PR DESCRIPTION
Set `xdms_hostname` to Homer's mgmt ip in local_config on Ellis instead of changing shared config just on Ellis.  This way changes are not lost when running `upload_shared_config` on another node.

I'll test this when I next spin up a fresh deployment in heat.
