### PR TITLE
[Reviewer: RKD] Restart clearwater-infrastructure before creating numbers

### DIFF
--- a/ellis.yaml
+++ b/ellis.yaml
@@ -210,7 +210,11 @@ resources:
             EOF
             sudo /usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config
 
-            # Allocate a allocate a pool of numbers to assign to users.
+            # Allocate a pool of numbers to assign to users.  Before we do this,
+            # restart clearwater-infrastructure to make sure that
+            # local_settings.py runs to pick up the configuration changes.
+            service clearwater-infrastructure restart
+            service ellis stop
             /usr/share/clearwater/ellis/env/bin/python /usr/share/clearwater/ellis/src/metaswitch/ellis/tools/create_numbers.py --start __dn_range_start__ --count __dn_range_length__
 
             # Function to give DNS record type and IP address for specified IP address


### PR DESCRIPTION
When testing #36, I found that Ellis created users with the default zone, `cw-ngv.com`.  This was because I deleted the `service clearwater-infrastructure restart` line which meant we failed to run local_settings.py.

The fix here is to reinstate this line in the same block of code as create_numbers.py so that they can't be separated in future.

Tested in Openstack and users are created properly now.
