### PR TITLE
Remove hardcoded shared_config file location

### DIFF
--- a/ellis.yaml
+++ b/ellis.yaml
@@ -160,8 +160,8 @@ resources:
             /usr/share/clearwater/clearwater-etcd/scripts/wait_for_etcd
 
             # Configure and upload /etc/clearwater/shared_config.
-            /usr/share/clearwater/clearwater-config-manager/scripts/cw-config download shared_config --autoconfirm
-            cat > $HOME/clearwater-config-manager/$USER/shared_config << EOF
+            LOCAL_SHARED_CFG=$(/usr/share/clearwater/clearwater-config-manager/scripts/cw-config download shared_config --autoconfirm |sed 's/shared_config downloaded to //')
+            cat > $LOCAL_SHARED_CFG << EOF
             # Deployment definitions
             home_domain=__zone__
             sprout_hostname=sprout.__zone__


### PR DESCRIPTION
Grab the location dynamically instead.

What do you think? If we hardcode the directory that feels pretty horrible. If we try and grab it from the output that feels better but then is at risk from anyone changing the text. The only robust thing seems to be allowing you to specify a location on the upload/download but I'm loathe to add that function in order to make this HEAT template work...

(and, yuck, this code just feels horrible - jumping around trying to handle the bizarre situation of not being able to get a username. )